### PR TITLE
Load cl-lib.el for using its macros

### DIFF
--- a/projectile-hanami.el
+++ b/projectile-hanami.el
@@ -46,6 +46,7 @@
 (require 'projectile)
 (require 'rake)
 (require 'inf-ruby)
+(require 'cl-lib)
 
 (defgroup projectile-hanami nil
   "Hanami mode based on Projectile"
@@ -127,10 +128,10 @@ The DIRS is list of lists consisting of a directory path and regexp to filter
 files from that directory.  Returns a hash table with keys being short names and
 values being relative paths to the files."
   (let ((hash (make-hash-table :test 'equal)))
-    (loop for (dir re) in dirs do
-          (loop for file in (projectile-dir-files (projectile-expand-root dir)) do
-                (when (string-match re file)
-                  (puthash (projectile-hanami-concat-string-matches re file "/") file hash))))
+    (cl-loop for (dir re) in dirs do
+             (cl-loop for file in (projectile-dir-files (projectile-expand-root dir)) do
+                      (when (string-match re file)
+                        (puthash (projectile-hanami-concat-string-matches re file "/") file hash))))
     hash))
 
 (defun projectile-hanami-hash-keys (hash)


### PR DESCRIPTION
And use cl-lib macros instead cl.el.

This fixes following byte-compile warnings.

```
In projectile-hanami-choices:
projectile-hanami.el:131:17:Warning: reference to free variable ‘for’
projectile-hanami.el:132:37:Warning: reference to free variable ‘re’
projectile-hanami.el:131:26:Warning: reference to free variable ‘in’
projectile-hanami.el:130:32:Warning: reference to free variable ‘do’
projectile-hanami.el:131:21:Warning: reference to free variable ‘file’
projectile-hanami.el:131:52:Warning: reference to free variable ‘dir’

In end of data:
projectile-hanami.el:434:1:Warning: the following functions are not known to be defined: loop, dir
```
